### PR TITLE
feat: add kubecost manifest and agent guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,25 @@
+# AGENTS Instructions
+
+This repository hosts examples and configuration for deploying Kubecost to Kubernetes clusters such as AWS EKS.
+
+## General Guidelines
+- Use `rg` for searching the codebase instead of `grep -R` or `ls -R`.
+- Keep line lengths under 120 characters.
+
+## Kubernetes Manifests
+- Validate any changed `.yaml` files with:
+  ```bash
+  python - <<'PY'
+import sys, yaml; yaml.safe_load(open(sys.argv[1]))
+PY kubecost.yaml
+  ```
+  Replace `kubecost.yaml` with the manifest being tested.
+- Prefer explicit `apiVersion` and `kind` declarations.
+
+## Commit Messages
+- Follow [Conventional Commits](https://www.conventionalcommits.org/) style (e.g., `feat:`, `fix:`, `docs:`).
+
+## Testing
+- Run the YAML validation command above for each modified Kubernetes manifest.
+- If Go code is changed, run `go fmt ./...` and `go test ./...`.
+

--- a/kubecost.yaml
+++ b/kubecost.yaml
@@ -1,0 +1,60 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kubecost
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kubecost-cost-analyzer
+  namespace: kubecost
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kubecost-cost-analyzer
+  namespace: kubecost
+data:
+  prometheus-server-endpoint: "http://prometheus-server.kube-system.svc"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kubecost-cost-analyzer
+  namespace: kubecost
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kubecost-cost-analyzer
+  template:
+    metadata:
+      labels:
+        app: kubecost-cost-analyzer
+    spec:
+      serviceAccountName: kubecost-cost-analyzer
+      containers:
+      - name: cost-analyzer
+        image: gcr.io/kubecost1/cost-analyzer:v1.100.0
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 9090
+        env:
+        - name: KUBERNETES_SERVICE_HOST
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kubecost-cost-analyzer
+  namespace: kubecost
+spec:
+  selector:
+    app: kubecost-cost-analyzer
+  type: LoadBalancer
+  ports:
+  - name: http
+    port: 9090
+    targetPort: 9090


### PR DESCRIPTION
## Summary
- add AGENTS instructions for working with kubecost manifests
- provide kubecost.yaml to deploy Kubecost on AWS EKS

## Testing
- `python - <<'PY'
import yaml; list(yaml.safe_load_all(open('kubecost.yaml')))
print('kubecost.yaml OK')
PY`


------
https://chatgpt.com/codex/tasks/task_e_6898a41b3f40832c9e4bb48e9b86cd05