### PR TITLE
Add Kubecost EKS deployment manifests

### DIFF
--- a/deploy/kubecost/README.md
+++ b/deploy/kubecost/README.md
@@ -1,0 +1,26 @@
+# Kubecost on EKS
+
+This guide describes how to install Kubecost on an Amazon EKS cluster and expose the Web Console over HTTPS using an AWS Application Load Balancer.
+
+## Prerequisites
+- EKS cluster (`>=1.26`) with OIDC and AWS Load Balancer Controller enabled
+- Namespace `kubecost`
+- ACM certificate for `kubecost.jhun80.click`
+- IAM role `kubecost-irsa` with Cost Explorer permissions
+- Existing Prometheus at `http://prometheus-server.monitoring.svc:80`
+- StorageClass `gp2`
+
+## Installation
+```bash
+helm upgrade -i kubecost oci://public.ecr.aws/kubecost/cost-analyzer \
+  --version 2.8.1 -n kubecost \
+  -f deploy/kubecost/kubecost.yaml --create-namespace
+```
+
+## Access
+The Web Console is exposed at `https://kubecost.jhun80.click` via an ALB. Verify by opening the URL in a browser.
+
+## Operations Checklist
+- Ensure workloads are labeled with `team`, `env`, and `owner`
+- Review Allocation, Assets and Savings dashboards after deployment
+- Generate monthly cost reports and prune unused resources

--- a/deploy/kubecost/ingress.yaml
+++ b/deploy/kubecost/ingress.yaml
@@ -1,0 +1,27 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: kubecost
+  namespace: kubecost
+  annotations:
+    kubernetes.io/ingress.class: alb
+    alb.ingress.kubernetes.io/scheme: internet-facing
+    alb.ingress.kubernetes.io/certificate-arn: arn:aws:acm:ap-northeast-2:111122223333:certificate/xxxx
+    alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS":443}]'
+    alb.ingress.kubernetes.io/target-type: ip
+spec:
+  rules:
+    - host: kubecost.jhun80.click
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: kubecost-cost-analyzer
+                port:
+                  number: 9090
+  tls:
+    - hosts:
+        - kubecost.jhun80.click
+      secretName: kubecost-tls

--- a/deploy/kubecost/irsa.yaml
+++ b/deploy/kubecost/irsa.yaml
@@ -1,0 +1,34 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kubecost
+  namespace: kubecost
+  annotations:
+    eks.amazonaws.com/role-arn: arn:aws:iam::111122223333:role/kubecost-irsa
+---
+AWSTemplateFormatVersion: '2010-09-09'
+Description: IAM role for Kubecost IRSA
+Resources:
+  KubecostRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: kubecost-irsa
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Federated: arn:aws:iam::111122223333:oidc-provider/oidc.eks.ap-northeast-2.amazonaws.com/id/EXAMPLED539D4633E53DE1B716D3041E
+            Action: sts:AssumeRoleWithWebIdentity
+            Condition:
+              StringEquals:
+                oidc.eks.ap-northeast-2.amazonaws.com/id/EXAMPLED539D4633E53DE1B716D3041E:sub: "system:serviceaccount:kubecost:kubecost"
+      Policies:
+        - PolicyName: kubecost
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - ce:GetCostAndUsage
+                Resource: "*"

--- a/deploy/kubecost/kubecost.yaml
+++ b/deploy/kubecost/kubecost.yaml
@@ -1,0 +1,44 @@
+# Kubecost Helm values for EKS deployment
+kubecostModel:
+  imageVersion: "2.8.1"
+  persistence:
+    enabled: true
+    storageClass: "gp2"
+    size: "50Gi"
+  resources:
+    requests:
+      cpu: 500m
+      memory: 1Gi
+    limits:
+      cpu: 1
+      memory: 2Gi
+
+prometheus:
+  enabled: false
+  serviceMonitor:
+    enabled: false
+
+kubecostProductConfigs:
+  clusterName: "eks-prod"
+  prometheusEndpoint: "http://prometheus-server.monitoring.svc:80"
+  cloudProvider: "AWS"
+
+serviceAccount:
+  create: false
+  name: kubecost
+
+ingress:
+  enabled: true
+  annotations:
+    kubernetes.io/ingress.class: alb
+    alb.ingress.kubernetes.io/scheme: internet-facing
+    alb.ingress.kubernetes.io/certificate-arn: arn:aws:acm:ap-northeast-2:111122223333:certificate/xxxx
+    alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS":443}]'
+  hosts:
+    - host: kubecost.jhun80.click
+      paths:
+        - /
+  tls: []
+
+networkPolicies:
+  enabled: false

--- a/deploy/kubecost/networkpolicy.yaml
+++ b/deploy/kubecost/networkpolicy.yaml
@@ -1,0 +1,26 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: kubecost-restrict
+  namespace: kubecost
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              name: kubecost
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              name: kubecost
+        - namespaceSelector:
+            matchLabels:
+              name: kube-system
+      ports:
+        - protocol: TCP
+          port: 443

--- a/reports/kubecost-validate-20250810235556.md
+++ b/reports/kubecost-validate-20250810235556.md
@@ -1,0 +1,10 @@
+# Kubecost Deployment Validation - 2025-08-10
+
+## Helm Template
+Attempted to run `helm template` but Helm was not installed. Installation failed due to 403 responses from `get.helm.sh`.
+
+## Ingress Test
+Ingress manifest configured for host `kubecost.jhun80.click`. Connectivity not tested in this environment.
+
+## Dashboard Check
+Web console reachability could not be verified within the build environment.


### PR DESCRIPTION
## Summary
- add Helm values for Kubecost with persistence, IRSA and ALB settings
- provide ALB ingress, IRSA, and network policy manifests
- include validation report and installation guide

## Testing
- `helm template kubecost oci://public.ecr.aws/kubecost/cost-analyzer -f deploy/kubecost/kubecost.yaml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689930f8a508832cb8f4bef2278c2371