### PR TITLE
Enable bundled Prometheus and document cost sources

### DIFF
--- a/deploy/kubecost/README.md
+++ b/deploy/kubecost/README.md
@@ -7,8 +7,7 @@ This guide describes how to install Kubecost on an Amazon EKS cluster and expose
 - Namespace `kubecost`
 - ACM certificate for `kubecost.jhun80.click`
 - IAM role `kubecost-irsa` with Cost Explorer permissions
-- Existing Prometheus at `http://prometheus-server.monitoring.svc:80`
-- StorageClass `gp2`
+- StorageClass `gp2` (used for Kubecost and the bundled Prometheus)
 
 ## Installation
 ```bash
@@ -23,4 +22,5 @@ The Web Console is exposed at `https://kubecost.jhun80.click` via an ALB. Verify
 ## Operations Checklist
 - Ensure workloads are labeled with `team`, `env`, and `owner`
 - Review Allocation, Assets and Savings dashboards after deployment
+- Confirm cost data is collected from Kubernetes, EBS, EC2 and S3 sources
 - Generate monthly cost reports and prune unused resources

--- a/deploy/kubecost/kubecost.yaml
+++ b/deploy/kubecost/kubecost.yaml
@@ -14,14 +14,21 @@ kubecostModel:
       memory: 2Gi
 
 prometheus:
-  enabled: false
-  serviceMonitor:
-    enabled: false
+  enabled: true
+  server:
+    persistentVolume:
+      enabled: true
+      storageClass: "gp2"
+      size: "50Gi"
 
 kubecostProductConfigs:
   clusterName: "eks-prod"
-  prometheusEndpoint: "http://prometheus-server.monitoring.svc:80"
   cloudProvider: "AWS"
+  costSources:
+    - kubernetes
+    - ebs
+    - ec2
+    - s3
 
 serviceAccount:
   create: false

--- a/reports/kubecost-validate-20250811002336.md
+++ b/reports/kubecost-validate-20250811002336.md
@@ -1,0 +1,13 @@
+# Kubecost Deployment Validation - 2025-08-11
+
+## Helm Template
+Attempted to install Helm using the official script and GitHub releases, but downloads returned 403/404 errors. The `helm template` command was not executed.
+
+## Dry-run Apply
+`kubectl` was not available and package installation failed, so `kubectl apply --dry-run=server` could not be run.
+
+## Ingress Test
+Ingress manifest configured for host `kubecost.jhun80.click`. Connectivity not tested in this environment.
+
+## Dashboard Check
+Web console reachability could not be verified within the build environment.


### PR DESCRIPTION
## Summary
- enable bundled Prometheus with persistent gp2 storage and cost source configuration
- document gp2 storage usage and cost-source checks in Kubecost README
- record validation attempts for Helm and kubectl

## Testing
- `curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3` *(failed: 403 from get.helm.sh)*
- `apt-get install -y kubectl` *(failed: Unable to locate package kubectl)*

------
https://chatgpt.com/codex/tasks/task_e_6899370fc76c832cb9d3c733691a05a0